### PR TITLE
Align repo metadata and workflows with ExpressVPN stack

### DIFF
--- a/.github/ISSUE_TEMPLATE/monthly-ops-checklist.yml
+++ b/.github/ISSUE_TEMPLATE/monthly-ops-checklist.yml
@@ -19,7 +19,7 @@ body:
         - label: Confirm stack health (`docker compose ps`)
         - label: Review Dependabot PRs and workflow updates
         - label: Review pinned image tags and upstream release notes
-        - label: Validate external access to qBittorrent, Jackett, FlareSolverr
+        - label: Validate ExpressVPN, qBittorrent, Jackett, and FlareSolverr health/access
 
   - type: textarea
     id: notes

--- a/.github/workflows/backup-restore-reminder.yml
+++ b/.github/workflows/backup-restore-reminder.yml
@@ -42,7 +42,7 @@ jobs:
               "- [ ] Run config backup command from README",
               "- [ ] Restore to a test location or temporary stack",
               "- [ ] Bring stack up and verify service health",
-              "- [ ] Confirm qBittorrent, Jackett, and FlareSolverr access",
+              "- [ ] Confirm ExpressVPN, qBittorrent, Jackett, and FlareSolverr health/access",
               "- [ ] Document any issues found"
             ].join('\n');
 

--- a/.github/workflows/compose-validate.yml
+++ b/.github/workflows/compose-validate.yml
@@ -39,7 +39,7 @@ jobs:
         if: env.EXPRESSVPN_ACTIVATION_CODE != ''
         run: |
           set -euo pipefail
-          services=(flaresolverr jackett qbittorrent)
+          services=(expressvpn flaresolverr jackett qbittorrent)
           timeout_seconds=240
           start_time=$(date +%s)
 


### PR DESCRIPTION
## Summary
This follow-up updates repository metadata and GitHub automation wording to match the current ExpressVPN-based stack.

## Changes
- Updated the GitHub repo description to reference ExpressVPN instead of WireGuard
- Updated the compose smoke test to wait for xpressvpn health alongside the other services
- Updated maintenance/reminder checklist text to include ExpressVPN health/access checks

## Files changed
- .github/workflows/compose-validate.yml
- .github/workflows/backup-restore-reminder.yml
- .github/ISSUE_TEMPLATE/monthly-ops-checklist.yml

## Validation
- Confirmed repo About text now reflects ExpressVPN
- Reviewed GitHub workflows and repo-facing automation text for stale wording
- Verified only the relevant workflow/template files required changes

## Why
The repository had already been migrated to an ExpressVPN-based routing model, but the repo description and some ongoing maintenance/validation text still lagged behind that change. This keeps GitHub metadata and automation consistent with the actual stack.