### PR TITLE
Pin Pester to 5.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          if (-not (Get-Module -ListAvailable -Name Pester)) {
-            Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck
-          }
-          Invoke-Pester ./tests/shared-functions.Tests.ps1
+          Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck -RequiredVersion 5.7.1
+          Import-Module Pester -RequiredVersion 5.7.1 -Force
+          Invoke-Pester ./tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Thanks for contributing to this project.
 - Keep changes focused and small.
 - Install local lint dependencies once per machine:
   - `Install-Module PSScriptAnalyzer -Scope CurrentUser -Force -AllowClobber`
+- Install the required Pester version for local test runs:
+  - `Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck -RequiredVersion 5.7.1`
 - Run local checks before opening a PR:
   - `git hook run pre-commit`
   - `docker compose config`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pwsh ./scripts/torrents-stack.ps1 test-all
 pwsh ./scripts/torrents-stack.ps1 report
 ```
 
+- Local Pester-based test runs require Pester 5.7.1: `Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck -RequiredVersion 5.7.1`.
 - The generated report reflects current runtime state at report time.
 - If you run `report` immediately after `test-all`, expect no running services in the compose state section because the test sequence intentionally cleans up at the end.
 - If you need live endpoint checks in the report after a full sequence, run `pwsh ./scripts/torrents-stack.ps1 start` before `report`.

--- a/scripts/torrents-stack.ps1
+++ b/scripts/torrents-stack.ps1
@@ -810,7 +810,18 @@ function Invoke-RepoPesterTests {
     if (Test-Path -LiteralPath $testPath) {
         $testFiles = @(Get-ChildItem -LiteralPath $testPath -Filter '*.Tests.ps1' -File | Sort-Object -Property Name | ForEach-Object { $_.Name })
     }
-    $output = @(pwsh -NoProfile -Command "Invoke-Pester -Path './tests'" 2>&1)
+    $requiredPesterVersion = '5.7.1'
+    $pesterCommand = @"
+$requiredVersion = [version]'$requiredPesterVersion'
+$availableModule = Get-Module -ListAvailable -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
+if (-not $availableModule -or $availableModule.Version -lt $requiredVersion) {
+    throw "Pester $requiredPesterVersion or newer is required. Install it with: Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck -RequiredVersion $requiredPesterVersion"
+}
+
+Import-Module Pester -MinimumVersion $requiredPesterVersion -Force
+Invoke-Pester -Path './tests'
+"@
+    $output = @(pwsh -NoProfile -Command $pesterCommand 2>&1)
 
     return [pscustomobject]@{
         Output = $output


### PR DESCRIPTION
## Summary
- pin CI to Pester 5.7.1 and run the full test suite
- require Pester 5.7.1 or newer in the wrapper test runner
- document the local Pester requirement in README and CONTRIBUTING

## Validation
- Import-Module Pester -RequiredVersion 5.7.1 -Force; Invoke-Pester ./tests
- pwsh -NoProfile -File ./scripts/validate-config.ps1