### PR TITLE
Disable scheduled reminder workflows

### DIFF
--- a/.github/workflows/backup-restore-reminder.yml
+++ b/.github/workflows/backup-restore-reminder.yml
@@ -1,8 +1,6 @@
 name: Backup Restore Reminder
 
 on:
-  schedule:
-    - cron: "0 14 1 * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependabot-monthly-review.yml
+++ b/.github/workflows/dependabot-monthly-review.yml
@@ -1,8 +1,6 @@
 name: Dependabot Monthly Review
 
 on:
-  schedule:
-    - cron: "0 16 1 * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/image-tag-drift.yml
+++ b/.github/workflows/image-tag-drift.yml
@@ -1,8 +1,6 @@
 name: Image Tag Drift Check
 
 on:
-  schedule:
-    - cron: "0 15 1 * *"
   workflow_dispatch:
 
 permissions:
@@ -44,17 +42,17 @@ jobs:
           def normalize(value):
               return value.strip().lstrip("v")
 
-            def inspect_image(image_ref):
+          def inspect_image(image_ref):
               inspect = run(["docker", "image", "inspect", image_ref])
               data = json.loads(inspect.stdout)[0]
               labels = data.get("Config", {}).get("Labels") or {}
               repo_digests = data.get("RepoDigests") or []
               digest = ""
               if repo_digests:
-                digest = repo_digests[0].split("@", 1)[1]
+                  digest = repo_digests[0].split("@", 1)[1]
               return {
-                "version": (labels.get("org.opencontainers.image.version") or "").strip(),
-                "digest": digest,
+                  "version": (labels.get("org.opencontainers.image.version") or "").strip(),
+                  "digest": digest,
               }
 
           env = load_env(ENV_FILE)
@@ -89,27 +87,27 @@ jobs:
                   })
                   continue
 
-                run(["docker", "pull", f"{image}:latest"])
-                latest_meta = inspect_image(f"{image}:latest")
-                latest_version = latest_meta["version"] or "latest"
-                latest_digest = latest_meta["digest"]
+              run(["docker", "pull", f"{image}:latest"])
+              latest_meta = inspect_image(f"{image}:latest")
+              latest_version = latest_meta["version"] or "latest"
+              latest_digest = latest_meta["digest"]
 
-                run(["docker", "pull", f"{image}:{pinned}"])
-                pinned_meta = inspect_image(f"{image}:{pinned}")
-                pinned_digest = pinned_meta["digest"]
+              run(["docker", "pull", f"{image}:{pinned}"])
+              pinned_meta = inspect_image(f"{image}:{pinned}")
+              pinned_digest = pinned_meta["digest"]
 
-                version_matches = normalize(pinned) == normalize(latest_version)
-                digest_matches = bool(latest_digest and pinned_digest and latest_digest == pinned_digest)
+              version_matches = normalize(pinned) == normalize(latest_version)
+              digest_matches = bool(latest_digest and pinned_digest and latest_digest == pinned_digest)
 
-                if not version_matches and not digest_matches:
+              if not version_matches and not digest_matches:
                   latest_reference = latest_version
                   if latest_reference == "latest" and latest_digest:
-                    latest_reference = latest_digest
+                      latest_reference = latest_digest
                   outdated.append({
                       "service": service,
                       "env_key": env_key,
                       "pinned": pinned,
-                    "latest": latest_reference,
+                      "latest": latest_reference,
                       "reason": "Configured tag differs from latest image version",
                   })
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ HEALTHCHECK_START_PERIOD=45s
 	- Expected: stack returns to last tagged baseline
 
 ## Backup and restore
-The repository includes a monthly reminder workflow that opens a backup/restore verification issue:
+The repository includes a manually runnable workflow for opening a backup/restore verification issue:
 - `Backup Restore Reminder` workflow: https://github.com/LBates2000/torrents-stack-expressvpn/actions/workflows/backup-restore-reminder.yml
 
 The bundled PowerShell helpers also respect `HOST_CONFIGS_DIR` and `HOST_DOWNLOADS_DIR`, so backup and restore follow the same directories used by the sync scripts and compose mounts:
@@ -300,7 +300,7 @@ pwsh ./scripts/restore-configs.ps1 -Archive .\backups\stack-backup-<timestamp>.z
 - Use GitHub issue templates for monthly maintenance and backup restore drills.
 - License: MIT (`LICENSE`).
 - Contribution guide: see `CONTRIBUTING.md`.
-- Scheduled image tag drift check: `.github/workflows/image-tag-drift.yml`.
+- Manual image tag drift check: `.github/workflows/image-tag-drift.yml`.
 
 ## Author
 - Lawrence Bates (<Lawrence.Bates@gmail.com>)


### PR DESCRIPTION
## Summary
- remove cron schedules from the maintenance reminder workflows while keeping manual dispatch enabled
- update README to describe the workflows as manual-only
- keep the image tag drift workflow valid for manual runs

## Validation
- no remaining schedule triggers in .github/workflows/*.yml
- checked edited files for YAML/Markdown errors